### PR TITLE
Allow dots in GitHub repo names

### DIFF
--- a/app/views/createNewRepo.scala.html
+++ b/app/views/createNewRepo.scala.html
@@ -20,7 +20,7 @@
                 '_label -> "Repository name",
                 'maxlength -> "100",
                 'required -> true,
-                'pattern -> "^[A-Za-z0-9_-]+$",
+                'pattern -> "^[A-Za-z0-9_-\.]+$",
                 'autofocus -> true) { input =>
                 <div class="input-group" >
                     <span class="input-group-addon">


### PR DESCRIPTION
Dots are allowed in GitHub repo names. You can even create a special
GitHub repo called `.github`, which may contain all your community
health files such as CODE_OF_CONDUCT.md and CONTRIBUTING.md
https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file-for-your-organization

This is what I was attempting to do when I came across this bug 😄 