### PR TITLE
Upgrade to sbt v1.6.0-RC1, hopefully reduce Heroku timeouts...

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.0-M1
+sbt.version=1.6.0-RC1


### PR DESCRIPTION
With https://github.com/sbt/sbt/pull/6729, the executor-shutdown timeout of 1 second has been increased to 30 seconds, which should mean fewer timeouts while building/deploying on Heroku.

See also:

* https://github.com/sbt/sbt/releases/tag/v1.6.0-RC1
* https://github.com/sbt/sbt/pull/5711#pullrequestreview-814258148
